### PR TITLE
Hotfix: `TemplateNotFound` Issues

### DIFF
--- a/canteen/logic/template.py
+++ b/canteen/logic/template.py
@@ -527,6 +527,7 @@ with runtime.Library('jinja2', strict=True) as (library, jinja2):
           module = importlib.import_module(module)
         except ImportError:
           # @TODO(sgammon): log if not found
+          if strict: raise
           raise jinja2.TemplateNotFound('Failed to locate compiled template'
                                         ' %s. %s' % (module, (
                                         'Strict mode was active.' if (
@@ -768,8 +769,6 @@ class Templates(logic.Logic):
         _path = (path.join(cwd),
                  path.join(cwd, 'templates'),
                  path.join(cwd, 'templates', 'source'))
-
-      import pdb; pdb.set_trace()
 
       # shim-in our loader system, unless it is overriden in config
       if 'loader' not in jinja2_cfg:

--- a/canteen_tests/test_logic/test_template.py
+++ b/canteen_tests/test_logic/test_template.py
@@ -122,7 +122,8 @@ if jinja2:
 
       """ Test constructing an invalid `ModuleLoader` """
 
-      template.ModuleLoader('hahaidonotexistfuckyou', strict=False)
+      with self.assertRaises(jinja2.TemplateNotFound):
+        template.ModuleLoader('hahaidonotexistfuckyou')
 
     def test_construct_strict_invalid(self):
 


### PR DESCRIPTION
This pull request fixes FLY-43 (which corresponds with GH #35), wherein constructing a `ModuleLoader` for templates where the root template package doesn't exist yields a `TemplateNotFound` error.

The new behavior is:
1) If `force_compiled` is on, force an `ImportError`
2) If `force_compiled` is not on and there are source templates, simply use those

Everything is still covered by tests and junk.
